### PR TITLE
Fix PHP 8.1 linting errors

### DIFF
--- a/src/com/amazon/paapi5/v1/BrowseNodeChildren.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeChildren.php
@@ -42,7 +42,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        
+
     ];
 
     /**
@@ -51,7 +51,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        
+
     ];
 
     /**
@@ -81,7 +81,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        
+
     ];
 
     /**
@@ -90,7 +90,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        
+
     ];
 
     /**
@@ -99,7 +99,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        
+
     ];
 
     /**
@@ -143,9 +143,9 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
         return self::$swaggerModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -171,9 +171,7 @@ class BrowseNodeChildren implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/src/com/amazon/paapi5/v1/Properties.php
+++ b/src/com/amazon/paapi5/v1/Properties.php
@@ -42,7 +42,7 @@ class Properties implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        
+
     ];
 
     /**
@@ -51,7 +51,7 @@ class Properties implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        
+
     ];
 
     /**
@@ -81,7 +81,7 @@ class Properties implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        
+
     ];
 
     /**
@@ -90,7 +90,7 @@ class Properties implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        
+
     ];
 
     /**
@@ -99,7 +99,7 @@ class Properties implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        
+
     ];
 
     /**
@@ -143,9 +143,9 @@ class Properties implements ModelInterface, ArrayAccess
         return self::$swaggerModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -171,9 +171,7 @@ class Properties implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**


### PR DESCRIPTION
[CRE-669](https://mediavine.atlassian.net/browse/CRE-669)

`parent` is invalid in both uses that are hereby removed. With no other functionality, these methods simply return an empty array now.

My IDE also fixed some errant space issues that I'm not turning off just for this PR.